### PR TITLE
Feat: remove dynamodb support

### DIFF
--- a/benchmarks/benchmarks_test.go
+++ b/benchmarks/benchmarks_test.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/quagmt/udecimal"
 
-	gv "github.com/govalues/decimal"
 	ss "github.com/shopspring/decimal"
 )
 
@@ -264,24 +263,6 @@ func BenchmarkDiv(b *testing.B) {
 			b.ResetTimer()
 			for range b.N {
 				_ = a.Div(bb)
-			}
-		})
-
-		// govalues benchmark
-		b.Run(fmt.Sprintf("gv/%s.Div(%s)", tc.a, tc.b), func(b *testing.B) {
-			a, err := gv.Parse(tc.a)
-			if err != nil {
-				return
-			}
-
-			bb, err := gv.Parse(tc.b)
-			if err != nil {
-				return
-			}
-
-			b.ResetTimer()
-			for range b.N {
-				_, _ = a.Quo(bb)
 			}
 		})
 

--- a/codec.go
+++ b/codec.go
@@ -7,8 +7,6 @@ import (
 	"math/big"
 	"math/bits"
 	"unsafe"
-
-	"github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
 )
 
 // String returns the string representation of the decimal.
@@ -441,35 +439,4 @@ func (d NullDecimal) Value() (driver.Value, error) {
 	}
 
 	return d.Decimal.String(), nil
-}
-
-// MarshalDynamoDBAttributeValue implements the Marshaler interface
-// It supports marshalling udec.UDecimal to dynamoDB number (N)
-func (d Decimal) MarshalDynamoDBAttributeValue() (types.AttributeValue, error) {
-	return &types.AttributeValueMemberN{Value: d.String()}, nil
-}
-
-// UnmarshalDynamoDBAttributeValue implements the Unmarshaler interface
-// It supports unmarshalling from both N and S types to udec.UDecimal
-func (d *Decimal) UnmarshalDynamoDBAttributeValue(av types.AttributeValue) error {
-	switch av := av.(type) {
-	case *types.AttributeValueMemberN:
-		dec, err := Parse(av.Value)
-		if err != nil {
-			return err
-		}
-
-		*d = dec
-	case *types.AttributeValueMemberS:
-		dec, err := Parse(av.Value)
-		if err != nil {
-			return err
-		}
-
-		*d = dec
-	default:
-		return fmt.Errorf("can't unmarshal %T to Decimal: %T is not supported", av, av)
-	}
-
-	return nil
 }

--- a/codec_test.go
+++ b/codec_test.go
@@ -9,8 +9,6 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-
-	"github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
 )
 
 func TestStringFixed(t *testing.T) {
@@ -272,86 +270,6 @@ func TestNullScan(t *testing.T) {
 			}
 
 			require.Equal(t, tc.want.Decimal.String(), val)
-		})
-	}
-}
-
-func TestDynamodbMarshal(t *testing.T) {
-	testcases := []struct {
-		in string
-	}{
-		{"0"},
-		{"1"},
-		{"-1"},
-		{"123456789.123456789"},
-		{"-123456789.123456789"},
-		{"0.000000001"},
-		{"-0.000000001"},
-		{"123.123"},
-		{"-123.123"},
-		{"12345678901234567890123456789.1234567890123456789"},
-		{"-12345678901234567890123456789.1234567890123456789"},
-	}
-
-	for _, tc := range testcases {
-		t.Run(tc.in, func(t *testing.T) {
-			d := MustParse(tc.in)
-
-			av, err := d.MarshalDynamoDBAttributeValue()
-			require.NoError(t, err)
-
-			avN, ok := av.(*types.AttributeValueMemberN)
-			require.True(t, ok)
-
-			require.Equal(t, tc.in, avN.Value)
-		})
-	}
-}
-
-func TestDynamodbUnmarshal(t *testing.T) {
-	testcases := []struct {
-		in      types.AttributeValue
-		want    Decimal
-		wantErr error
-	}{
-		{&types.AttributeValueMemberN{Value: "0"}, MustParse("0"), nil},
-		{&types.AttributeValueMemberN{Value: "1"}, MustParse("1"), nil},
-		{&types.AttributeValueMemberN{Value: "-1"}, MustParse("-1"), nil},
-		{&types.AttributeValueMemberN{Value: "123456789.123456789"}, MustParse("123456789.123456789"), nil},
-		{&types.AttributeValueMemberN{Value: "-123456789.123456789"}, MustParse("-123456789.123456789"), nil},
-		{&types.AttributeValueMemberN{Value: "0.000000001"}, MustParse("0.000000001"), nil},
-		{&types.AttributeValueMemberN{Value: "-0.000000001"}, MustParse("-0.000000001"), nil},
-		{&types.AttributeValueMemberN{Value: "123.123"}, MustParse("123.123"), nil},
-		{&types.AttributeValueMemberN{Value: "-123.123"}, MustParse("-123.123"), nil},
-		{&types.AttributeValueMemberN{Value: "12345678901234567890123456789.1234567890123456789"}, MustParse("12345678901234567890123456789.1234567890123456789"), nil},
-		{&types.AttributeValueMemberN{Value: "-12345678901234567890123456789.1234567890123456789"}, MustParse("-12345678901234567890123456789.1234567890123456789"), nil},
-		{&types.AttributeValueMemberS{Value: "0"}, MustParse("0"), nil},
-		{&types.AttributeValueMemberS{Value: "1"}, MustParse("1"), nil},
-		{&types.AttributeValueMemberS{Value: "-1"}, MustParse("-1"), nil},
-		{&types.AttributeValueMemberS{Value: "123456789.123456789"}, MustParse("123456789.123456789"), nil},
-		{&types.AttributeValueMemberS{Value: "-123456789.123456789"}, MustParse("-123456789.123456789"), nil},
-		{&types.AttributeValueMemberS{Value: "0.000000001"}, MustParse("0.000000001"), nil},
-		{&types.AttributeValueMemberS{Value: "-0.000000001"}, MustParse("-0.000000001"), nil},
-		{&types.AttributeValueMemberS{Value: "123.123"}, MustParse("123.123"), nil},
-		{&types.AttributeValueMemberS{Value: "-123.123"}, MustParse("-123.123"), nil},
-		{&types.AttributeValueMemberS{Value: "12345678901234567890123456789.1234567890123456789"}, MustParse("12345678901234567890123456789.1234567890123456789"), nil},
-		{&types.AttributeValueMemberS{Value: "-12345678901234567890123456789.1234567890123456789"}, MustParse("-12345678901234567890123456789.1234567890123456789"), nil},
-		{&types.AttributeValueMemberBOOL{Value: true}, Decimal{}, fmt.Errorf("can't unmarshal %T to Decimal: %T is not supported", &types.AttributeValueMemberBOOL{}, &types.AttributeValueMemberBOOL{})},
-		{&types.AttributeValueMemberN{Value: "a"}, Decimal{}, fmt.Errorf("invalid format: can't parse 'a' to Decimal")},
-		{&types.AttributeValueMemberS{Value: "a"}, Decimal{}, fmt.Errorf("invalid format: can't parse 'a' to Decimal")},
-	}
-
-	for _, tc := range testcases {
-		t.Run(fmt.Sprintf("%v", tc.in), func(t *testing.T) {
-			var d Decimal
-			err := d.UnmarshalDynamoDBAttributeValue(tc.in)
-			if tc.wantErr != nil {
-				require.EqualError(t, tc.wantErr, err.Error())
-				return
-			}
-
-			require.NoError(t, err)
-			require.Equal(t, tc.want, d)
 		})
 	}
 }

--- a/doc.go
+++ b/doc.go
@@ -15,10 +15,9 @@
 // The udecimal package supports various encoding and decoding mechanisms to facilitate easy integration with
 // different data storage and transmission systems.
 //
-//   - Marshal/UnmarshalText: json, string
+//   - Marshal/UnmarshalJSON
 //   - Marshal/UnmarshalBinary: gob, protobuf
 //   - SQL: The Decimal type implements the sql.Scanner interface, enabling seamless integration with SQL databases.
-//   - DynamoDB: The package supports parsing DynamoDB number (regarless number or string) to Decimal and marshal Decimal back to DynamoDB number.
 //
 // For more details, see the documentation for each method.
 package udecimal

--- a/doc_test.go
+++ b/doc_test.go
@@ -2,8 +2,6 @@ package udecimal
 
 import (
 	"fmt"
-
-	"github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
 )
 
 func ExampleSetDefaultPrecision() {
@@ -252,16 +250,6 @@ func ExampleDecimal_MarshalBinary() {
 	// [0 19 19 9 73 176 246 240 2 51 19 211 181 5 249 181 241 129 21] <nil>
 }
 
-func ExampleDecimal_MarshalDynamoDBAttributeValue() {
-	fmt.Println(MustParse("1.23").MarshalDynamoDBAttributeValue())
-	fmt.Println(MustParse("-1.2345").MarshalDynamoDBAttributeValue())
-	fmt.Println(MustParse("1234567890123456789.1234567890123456789").MarshalDynamoDBAttributeValue())
-	// Output:
-	// &{1.23 {}} <nil>
-	// &{-1.2345 {}} <nil>
-	// &{1234567890123456789.1234567890123456789 {}} <nil>
-}
-
 func ExampleDecimal_MarshalJSON() {
 	a, _ := MustParse("1.23").MarshalJSON()
 	b, _ := MustParse("-1.2345").MarshalJSON()
@@ -390,14 +378,6 @@ func ExampleDecimal_Trunc() {
 func ExampleDecimal_UnmarshalBinary() {
 	var a Decimal
 	_ = a.UnmarshalBinary([]byte{0, 2, 11, 0, 0, 0, 0, 0, 0, 0, 123})
-	fmt.Println(a)
-	// Output:
-	// 1.23
-}
-
-func ExampleDecimal_UnmarshalDynamoDBAttributeValue() {
-	var a Decimal
-	_ = a.UnmarshalDynamoDBAttributeValue(&types.AttributeValueMemberN{Value: "1.23"})
 	fmt.Println(a)
 	// Output:
 	// 1.23

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,6 @@ module github.com/quagmt/udecimal
 go 1.23
 
 require (
-	github.com/govalues/decimal v0.1.31
 	github.com/shopspring/decimal v1.4.0
 	github.com/stretchr/testify v1.9.0
 )

--- a/go.mod
+++ b/go.mod
@@ -3,14 +3,12 @@ module github.com/quagmt/udecimal
 go 1.23
 
 require (
-	github.com/aws/aws-sdk-go-v2/service/dynamodb v1.35.0
 	github.com/govalues/decimal v0.1.31
 	github.com/shopspring/decimal v1.4.0
 	github.com/stretchr/testify v1.9.0
 )
 
 require (
-	github.com/aws/smithy-go v1.21.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,5 @@
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/govalues/decimal v0.1.31 h1:2NbQhpPIRR++4RIg3o3jO8GKhaOV21DkdBOkN7pd62I=
-github.com/govalues/decimal v0.1.31/go.mod h1:Ee7eI3Llf7hfqDZtpj8Q6NCIgJy1iY3kH1pSwDrNqlM=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/shopspring/decimal v1.4.0 h1:bxl37RwXBklmTi0C79JfXCEBD1cqqHt0bbgBAGFp81k=

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,3 @@
-github.com/aws/aws-sdk-go-v2/service/dynamodb v1.35.0 h1:r2HJyqAyQ96FtCxG1PkcbJHymPt+LmirbNQdW2lPudM=
-github.com/aws/aws-sdk-go-v2/service/dynamodb v1.35.0/go.mod h1:k5XW8MoMxsNZ20RJmsokakvENUwQyjv69R9GqrI4xdQ=
-github.com/aws/smithy-go v1.21.0 h1:H7L8dtDRk0P1Qm6y0ji7MCYMQObJ5R9CRpyPhRUkLYA=
-github.com/aws/smithy-go v1.21.0/go.mod h1:irrKGvNn1InZwb2d7fkIRNucdfwR8R+Ts3wxYa/cJHg=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/govalues/decimal v0.1.31 h1:2NbQhpPIRR++4RIg3o3jO8GKhaOV21DkdBOkN7pd62I=


### PR DESCRIPTION
## Description
- Remove dynamoDB support to avoid external dependencies. Will move the implementation to a different package instead.
- Remove govalues in benchmark. Might need to refactor test and move benchmark to a different repo, so this repo is completely dependency-free. However it's not high priority because those dependencies (shopspring/decimal, strechr/testify) are not included when importing this library (since they are only used for testing)