### PR TITLE
feat: add support for text-based encoding

### DIFF
--- a/bint.go
+++ b/bint.go
@@ -77,11 +77,6 @@ func parseBint(s []byte) (bool, bint, uint8, error) {
 		return false, bint{}, 0, ErrMaxStrLen
 	}
 
-	// unQuote if the string is quoted, usually when unmarshalling from JSON
-	if len(s) > 2 && s[0] == '"' && s[len(s)-1] == '"' {
-		s = s[1 : len(s)-1]
-	}
-
 	// if s has less than 41 characters, it can fit into u128
 	// 41 chars = maxLen(u128) + dot + sign = 39 + 1 + 1
 	if len(s) <= 41 {

--- a/codec.go
+++ b/codec.go
@@ -1,12 +1,25 @@
 package udecimal
 
 import (
+	"database/sql"
 	"database/sql/driver"
+	"encoding"
 	"encoding/binary"
+	"encoding/json"
 	"fmt"
 	"math/big"
 	"math/bits"
 	"unsafe"
+)
+
+var (
+	_ fmt.Stringer             = (*Decimal)(nil)
+	_ sql.Scanner              = (*Decimal)(nil)
+	_ driver.Valuer            = (*Decimal)(nil)
+	_ encoding.TextMarshaler   = (*Decimal)(nil)
+	_ encoding.TextUnmarshaler = (*Decimal)(nil)
+	_ json.Marshaler           = (*Decimal)(nil)
+	_ json.Unmarshaler         = (*Decimal)(nil)
 )
 
 // String returns the string representation of the decimal.
@@ -214,6 +227,7 @@ func unssafeStringToBytes(s string) []byte {
 	return unsafe.Slice(unsafe.StringData(s), len(s))
 }
 
+// MarshalJSON implements the [json.Marshaler] interface.
 func (d Decimal) MarshalJSON() ([]byte, error) {
 	if !d.coef.overflow() {
 		return d.bytesU128(true, true), nil
@@ -222,13 +236,31 @@ func (d Decimal) MarshalJSON() ([]byte, error) {
 	return []byte(`"` + d.stringBigInt(true) + `"`), nil
 }
 
+// UnmarshalJSON implements the [json.Unmarshaler] interface.
 func (d *Decimal) UnmarshalJSON(data []byte) error {
+	// Remove quotes if they exist.
+	if len(data) > 2 && data[0] == '"' && data[len(data)-1] == '"' {
+		data = data[1 : len(data)-1]
+	}
+
 	var err error
 	*d, err = parseBytes(data)
 	return err
 }
 
-// MarshalBinary implements encoding.BinaryMarshaler interface with custom binary format.
+// MarshalText implements the [encoding.TextMarshaler] interface.
+func (d Decimal) MarshalText() ([]byte, error) {
+	return []byte(d.String()), nil
+}
+
+// UnmarshalText implements the [encoding.TextUnmarshaler] interface.
+func (t *Decimal) UnmarshalText(data []byte) error {
+	var err error
+	*t, err = parseBytes(data)
+	return err
+}
+
+// MarshalBinary implements [encoding.BinaryMarshaler] interface with custom binary format.
 //
 //	Binary format: [overflow + neg] [prec] [total bytes] [coef]
 //
@@ -386,7 +418,7 @@ func (d *Decimal) Scan(src any) error {
 	return err
 }
 
-// Value implements driver.Valuer interface.
+// Value implements [driver.Valuer] interface.
 func (d Decimal) Value() (driver.Value, error) {
 	return d.String(), nil
 }

--- a/codec_test.go
+++ b/codec_test.go
@@ -54,6 +54,38 @@ func TestStringFixed(t *testing.T) {
 	}
 }
 
+func TestMarshalText(t *testing.T) {
+	testcases := []struct {
+		in string
+	}{
+		{"123456789.123456789"},
+		{"0"},
+		{"1"},
+		{"-1"},
+		{"-123456789.123456789"},
+		{"0.000000001"},
+		{"-0.000000001"},
+		{"123.123"},
+		{"-123.123"},
+		{"12345678901234567890123456789.1234567890123456789"},
+		{"-12345678901234567890123456789.1234567890123456789"},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.in, func(t *testing.T) {
+			a := MustParse(tc.in)
+
+			b, err := a.MarshalText()
+			require.NoError(t, err)
+
+			var c Decimal
+			require.NoError(t, c.UnmarshalText(b))
+
+			require.Equal(t, a, c)
+		})
+	}
+}
+
 type A struct {
 	P Decimal `json:"a"`
 }

--- a/decimal.go
+++ b/decimal.go
@@ -275,14 +275,12 @@ func Parse(s string) (Decimal, error) {
 }
 
 func parseBytes(b []byte) (Decimal, error) {
-
 	neg, bint, prec, err := parseBint(b)
 	if err != nil {
 		return Decimal{}, err
 	}
 
 	return newDecimal(neg, bint, prec), nil
-
 }
 
 // MustParse similars to Parse, but pacnis instead of returning error.

--- a/doc_test.go
+++ b/doc_test.go
@@ -271,6 +271,19 @@ func ExampleDecimal_MarshalJSON() {
 	// "1234567890123456789.1234567890123456789"
 }
 
+func ExampleDecimal_MarshalText() {
+	a, _ := MustParse("1.23").MarshalText()
+	b, _ := MustParse("-1.2345").MarshalText()
+	c, _ := MustParse("1234567890123456789.1234567890123456789").MarshalText()
+	fmt.Println(string(a))
+	fmt.Println(string(b))
+	fmt.Println(string(c))
+	// Output:
+	// 1.23
+	// -1.2345
+	// 1234567890123456789.1234567890123456789
+}
+
 func ExampleDecimal_Neg() {
 	fmt.Println(MustParse("1.23").Neg())
 	fmt.Println(MustParse("-1.23").Neg())
@@ -394,6 +407,14 @@ func ExampleDecimal_UnmarshalBinary() {
 func ExampleDecimal_UnmarshalJSON() {
 	var a Decimal
 	_ = a.UnmarshalJSON([]byte("1.23"))
+	fmt.Println(a)
+	// Output:
+	// 1.23
+}
+
+func ExampleDecimal_UnmarshalText() {
+	var a Decimal
+	_ = a.UnmarshalText([]byte("1.23"))
 	fmt.Println(a)
 	// Output:
 	// 1.23


### PR DESCRIPTION
Hey,

Currently the `Decimal` type does not support text-based encoding, for example YAML encoding will produce `{}` instead of a string representation of the decimal value.

This pull request implements the [`encoding.TextMarshaler`](https://pkg.go.dev/encoding#TextMarshaler) and [`encoding.TextUnmarshaler`](https://pkg.go.dev/encoding#TextUnmarshaler) interfaces which are recognized by many text-based encoding packages and libraries.