### PR TITLE
feat: add precUint

### DIFF
--- a/decimal.go
+++ b/decimal.go
@@ -584,6 +584,19 @@ func (d Decimal) Prec() int {
 	return int(d.prec)
 }
 
+// PrecUint returns decimal precision as uint8
+// Useful when you want to use the precision
+// in other functions like Round or Trunc because they accept uint8
+//
+// Example:
+//
+//	u := MustParse("0.000001")
+//	d := MustParse("123.4567891") // 123.456, prec = 3
+//	d = d.Trunc(u.PrecUint()) // 123.456789
+func (d Decimal) PrecUint() uint8 {
+	return d.prec
+}
+
 // Cmp compares two decimals d,e and returns:
 //
 //	-1 if d < e

--- a/decimal_test.go
+++ b/decimal_test.go
@@ -2290,3 +2290,34 @@ func TestCmpWithDiffPrec(t *testing.T) {
 		})
 	}
 }
+
+func TestPrecUint(t *testing.T) {
+	testcases := []struct {
+		a    string
+		want uint8
+	}{
+		{"0", 0},
+		{"0.123456789", 9},
+		{"-0.123456789", 9},
+		{"-123456789.123456789", 9},
+		{"1234567890123456789.1234567890123456789", 19},
+		{"-1234567890123456789.1234567890123456789", 19},
+		{"123456789123456789123456789.1234567890123456789", 19},
+		{"-123456789123456789123456789.1234567890123456789", 19},
+	}
+
+	oneUnit := MustParse("0.0001")
+
+	for _, tc := range testcases {
+		t.Run(fmt.Sprintf("precUint(%s)", tc.a), func(t *testing.T) {
+			a := MustParse(tc.a)
+			require.Equal(t, tc.want, a.PrecUint())
+
+			b := a.Trunc(oneUnit.PrecUint())
+			if a.prec > oneUnit.prec {
+				require.Equal(t, oneUnit.prec, b.PrecUint())
+			}
+		})
+
+	}
+}

--- a/doc_test.go
+++ b/doc_test.go
@@ -308,6 +308,12 @@ func ExampleDecimal_Prec() {
 	// 2
 }
 
+func ExampleDecimal_PrecUint() {
+	fmt.Println(MustParse("1.23456").PrecUint())
+	// Output:
+	// 5
+}
+
 func ExampleDecimal_RoundBank() {
 	fmt.Println(MustParse("1.12345").RoundBank(4))
 	fmt.Println(MustParse("1.12335").RoundBank(4))


### PR DESCRIPTION
## Description
- Add `PrecUint` method which returns precision as uint8. This function can be useful when combining with other functions like Round or Trunc as they accept `uint8` as input
- Example:

```go
oneUnit := udecimal.MustParse("0.001")
a := udecimal.MustParse("1.123456")
b := a.Trunc(oneUnit.PrecUint()) // b = 1.123
```