### PR TITLE
feat: add support for JSON null value

### DIFF
--- a/codec.go
+++ b/codec.go
@@ -1,6 +1,7 @@
 package udecimal
 
 import (
+	"bytes"
 	"database/sql"
 	"database/sql/driver"
 	"encoding"
@@ -236,11 +237,19 @@ func (d Decimal) MarshalJSON() ([]byte, error) {
 	return []byte(`"` + d.stringBigInt(true) + `"`), nil
 }
 
+// nullValue represents the JSON null value.
+var nullValue = []byte("null")
+
 // UnmarshalJSON implements the [json.Unmarshaler] interface.
 func (d *Decimal) UnmarshalJSON(data []byte) error {
 	// Remove quotes if they exist.
 	if len(data) >= 2 && data[0] == '"' && data[len(data)-1] == '"' {
 		data = data[1 : len(data)-1]
+	}
+
+	// null value.
+	if bytes.Equal(data, nullValue) {
+		return nil
 	}
 
 	return d.UnmarshalText(data)

--- a/codec_test.go
+++ b/codec_test.go
@@ -180,6 +180,13 @@ func TestUnmarshalJSON(t *testing.T) {
 	}
 }
 
+func TestUnmarshalJSONNull(t *testing.T) {
+	var test Test
+	err := json.Unmarshal([]byte(`{"price": null}`), &test)
+	require.NoError(t, err)
+	require.True(t, test.Test.IsZero())
+}
+
 func TestMarshalBinary(t *testing.T) {
 	testcases := []struct {
 		in string


### PR DESCRIPTION
Hey,

This pull request is a suggestion to add support for the JSON `null` value.
This is needed to prevent parse errors when an API returns a `null` value for a `udecimal.Decimal` type.

Other libraries like https://github.com/shopspring/decimal already support this.