### PR TITLE
fix: magic number in parsing

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -3,6 +3,7 @@ run:
 
 linters:
   enable:
+    - nolintlint
     - errcheck
     - gosimple
     - goimports

--- a/bint.go
+++ b/bint.go
@@ -178,7 +178,7 @@ func parseBint(s []byte) (bool, bint, uint8, error) {
 		return false, bint{}, 0, errInvalidFormat(s)
 	}
 
-	// nolint: gosec
+	//nolint:gosec
 	return neg, bintFromBigInt(dValue), uint8(prec), nil
 }
 
@@ -244,7 +244,7 @@ func parseSmallToU128(s []byte) (u128, uint8, error) {
 				return u128{}, 0, ErrInvalidFormat
 			}
 
-			// nolint: gosec
+			//nolint:gosec
 			prec = uint8(len(s) - i - 1)
 
 			// prevent "123." or "-123."
@@ -293,7 +293,7 @@ func parseLargeToU128(s []byte) (u128, uint8, error) {
 	}
 
 	// now 0 < pos < l-1
-	// nolint: gosec
+	//nolint:gosec
 	prec := uint8(l - pos - 1)
 	if prec > defaultPrec {
 		return u128{}, 0, ErrPrecOutOfRange

--- a/bint.go
+++ b/bint.go
@@ -1,9 +1,16 @@
 package udecimal
 
 import (
+	"bytes"
 	"fmt"
 	"math/big"
 	"strings"
+)
+
+const (
+	// maxDigitU64 is the maximum digits of a number
+	// that can be safely stored in a uint64.
+	maxDigitU64 = 19
 )
 
 var (
@@ -211,7 +218,7 @@ func parseBintFromU128(s []byte) (bool, bint, uint8, error) {
 		prec uint8
 	)
 
-	if len(s[pos:]) <= 19 {
+	if len(s[pos:]) <= maxDigitU64 {
 		coef, prec, err = parseSmallToU128(s[pos:])
 	} else {
 		coef, prec, err = parseLargeToU128(s[pos:])
@@ -269,25 +276,10 @@ func parseSmallToU128(s []byte) (u128, uint8, error) {
 func parseLargeToU128(s []byte) (u128, uint8, error) {
 	// find '.' position
 	l := len(s)
-	pos := -1
-
-	for i := 0; i < len(s); i++ {
-		if s[i] == '.' {
-			pos = i
-		}
-	}
-
+	pos := bytes.IndexByte(s, '.')
 	if pos == 0 || pos == l-1 {
+		// prevent ".123" or "123."
 		return u128{}, 0, ErrInvalidFormat
-	}
-
-	var prec uint8
-	if pos != -1 {
-		// nolint: gosec
-		prec = uint8(l - pos - 1)
-		if prec > defaultPrec {
-			return u128{}, 0, ErrPrecOutOfRange
-		}
 	}
 
 	if pos == -1 {
@@ -300,6 +292,13 @@ func parseLargeToU128(s []byte) (u128, uint8, error) {
 		return coef, 0, nil
 	}
 
+	// now 0 < pos < l-1
+	// nolint: gosec
+	prec := uint8(l - pos - 1)
+	if prec > defaultPrec {
+		return u128{}, 0, ErrPrecOutOfRange
+	}
+
 	// number has a decimal point, split into 2 parts: integer and fraction
 	intPart, err := digitToU128(s[:pos])
 	if err != nil {
@@ -307,7 +306,7 @@ func parseLargeToU128(s []byte) (u128, uint8, error) {
 	}
 
 	// because max prec is 19,
-	// factionPart can't be larger than 10%20-1 and will fit into uint64 (fractionPart.hi == 0)
+	// factionPart can't be larger than 10^19-1 and will fit into uint64 (fractionPart.hi == 0)
 	fractionPart, err := digitToU128(s[pos+1:])
 	if err != nil {
 		return u128{}, 0, err
@@ -328,7 +327,7 @@ func parseLargeToU128(s []byte) (u128, uint8, error) {
 }
 
 func digitToU128(s []byte) (u128, error) {
-	if len(s) <= 19 {
+	if len(s) <= maxDigitU64 {
 		var u uint64
 		for i := 0; i < len(s); i++ {
 			if s[i] < '0' || s[i] > '9' {

--- a/codec.go
+++ b/codec.go
@@ -166,7 +166,6 @@ func (d Decimal) fillBuffer(buf []byte, trimTrailingZeros bool) int {
 		for ; rem != 0; rem /= 10 {
 			n++
 
-			// nolint: gosec
 			buf[l-n] = byte(rem%10) + '0'
 		}
 
@@ -188,8 +187,7 @@ func (d Decimal) fillBuffer(buf []byte, trimTrailingZeros bool) int {
 			q, r := quoRem64(quo, 10)
 			n++
 
-			// nolint: gosec
-			buf[l-n] = uint8(r%10) + '0'
+			buf[l-n] = byte(r%10) + '0'
 			if q.IsZero() {
 				break
 			}

--- a/decimal.go
+++ b/decimal.go
@@ -429,10 +429,6 @@ func (d Decimal) Sub64(e uint64) Decimal {
 // Mul returns d * e.
 // The result will have at most defaultPrec digits after the decimal point.
 func (d Decimal) Mul(e Decimal) Decimal {
-	if e.coef.IsZero() {
-		return Decimal{}
-	}
-
 	prec := d.prec + e.prec
 	neg := d.neg != e.neg
 
@@ -1370,3 +1366,26 @@ func (d Decimal) sqrtU128() (Decimal, error) {
 
 	return newDecimal(false, bintFromU128(x), defaultPrec), nil
 }
+
+// goos: linux
+// goarch: amd64
+// pkg: github.com/quagmt/udecimal/benchmarks
+// cpu: Intel(R) Core(TM) i9-14900HX
+// BenchmarkMul/ss/1234.1234567890123456879.Mul(1111.1789)-32         	10858572	       107.1 ns/op	      96 B/op	       2 allocs/op
+// BenchmarkMul/udec/1234.1234567890123456879.Mul(1111.1789)-32       	135126661	         8.835 ns/op	       0 B/op	       0 allocs/op
+// BenchmarkMul/ss/1234.1234567890123456879.Mul(1111.1234567890123456789)-32         	11944191	       114.8 ns/op	      96 B/op	       2 allocs/op
+// BenchmarkMul/udec/1234.1234567890123456879.Mul(1111.1234567890123456789)-32       	136730773	         8.726 ns/op	       0 B/op	       0 allocs/op
+// BenchmarkMul/ss/123.456.Mul(0.123)-32                                             	17990072	        95.37 ns/op	      80 B/op	       2 allocs/op
+// BenchmarkMul/udec/123.456.Mul(0.123)-32                                           	187649670	         6.191 ns/op	       0 B/op	       0 allocs/op
+// BenchmarkMul/ss/3.Mul(7)-32                                                       	16913634	        98.32 ns/op	      80 B/op	       2 allocs/op
+// BenchmarkMul/udec/3.Mul(7)-32                                                     	194847196	         6.439 ns/op	       0 B/op	       0 allocs/op
+// BenchmarkMul/ss/123456.123456.Mul(999999)-32                                      	14550664	       101.1 ns/op	      80 B/op	       2 allocs/op
+// BenchmarkMul/udec/123456.123456.Mul(999999)-32                                    	181630240	         6.359 ns/op	       0 B/op	       0 allocs/op
+// BenchmarkMul/ss/123456.123456.Mul(456781244.1324897546)-32                        	23803376	        96.47 ns/op	      80 B/op	       2 allocs/op
+// BenchmarkMul/udec/123456.123456.Mul(456781244.1324897546)-32                      	188306853	         6.369 ns/op	       0 B/op	       0 allocs/op
+// BenchmarkMul/ss/548751.15465466546.Mul(1542.456487)-32                            	29261016	        95.77 ns/op	      80 B/op	       2 allocs/op
+// BenchmarkMul/udec/548751.15465466546.Mul(1542.456487)-32                          	190835786	         6.227 ns/op	       0 B/op	       0 allocs/op
+// BenchmarkMul/ss/0.Mul(1542.456487)-32                                             	55620909	        39.04 ns/op	      32 B/op	       1 allocs/op
+// BenchmarkMul/udec/0.Mul(1542.456487)-32                                           	196583198	         6.225 ns/op	       0 B/op	       0 allocs/op
+// PASS
+// ok  	github.com/quagmt/udecimal/benchmarks	29.377

--- a/decimal.go
+++ b/decimal.go
@@ -278,6 +278,7 @@ func (d Decimal) InexactFloat64() float64 {
 // Returns error if:
 //  1. empty/invalid string
 //  2. the number has more than 19 digits after the decimal point
+//  3. string length exceeds maxStrLen (which is 200 characters. See maxStrLen const for more details)
 func Parse(s string) (Decimal, error) {
 	return parseBytes(unsafeStringToBytes(s))
 }

--- a/decimal_test.go
+++ b/decimal_test.go
@@ -2339,12 +2339,3 @@ func TestPrecUint(t *testing.T) {
 		})
 	}
 }
-
-func BenchmarkDiv(b *testing.B) {
-	a := MustParse("22773757910726981402256170801141121114")
-	bb := MustParse("811656739243220271.159")
-
-	for i := 0; i < b.N; i++ {
-		_, _ = a.Div(bb)
-	}
-}

--- a/decimal_test.go
+++ b/decimal_test.go
@@ -564,7 +564,6 @@ func TestAdd(t *testing.T) {
 			aa := decimal.RequireFromString(tc.a)
 			bb := decimal.RequireFromString(tc.b)
 
-			// nolint: gosec
 			prec := int32(c.Prec())
 			cc := aa.Add(bb).Truncate(prec)
 

--- a/u128.go
+++ b/u128.go
@@ -137,6 +137,12 @@ func (u u128) Mul(v u128) (u128, error) {
 // MulToU256 returns u*v and carry.
 // The whole result will be stored in a 256-bits unsigned integer.
 func (u u128) MulToU256(v u128) u256 {
+	// short path for small numbers
+	if u.hi == 0 && v.hi == 0 {
+		hi, lo := bits.Mul64(u.lo, v.lo)
+		return u256{lo: lo, hi: hi}
+	}
+
 	hi, lo := bits.Mul64(u.lo, v.lo)
 	p0, p1 := bits.Mul64(u.hi, v.lo)
 	p2, p3 := bits.Mul64(u.lo, v.hi)

--- a/u128.go
+++ b/u128.go
@@ -189,7 +189,7 @@ func (u u128) QuoRem(v u128) (q, r u128, err error) {
 		// generate a "trial quotient," guaranteed to be within 1 of the actual
 		// quotient, then adjust.
 
-		// nolint: gosec
+		//nolint:gosec
 		n := uint(bits.LeadingZeros64(v.hi))
 		v1 := v.Lsh(n)
 		u1 := u.Rsh(1)

--- a/u256.go
+++ b/u256.go
@@ -165,7 +165,7 @@ func (u u256) div256by128(v u128) u128 {
 	// normalize v
 	n := bits.LeadingZeros64(v.hi)
 
-	// nolint: gosec
+	//nolint:gosec
 	v = v.Lsh(uint(n))
 
 	// shift u to the left by n bits (n < 64)


### PR DESCRIPTION
## Description
- Replaced magic number `19` by a constant to avoid confusion
- Add a short path in `MulToU256`, to avoid unnecessary computations
- Add notice for max string length error in `Parse`
- Add `nolintlint` linter