### PR TITLE
Fix: un-optimized codec 

### DIFF
--- a/codec.go
+++ b/codec.go
@@ -467,7 +467,7 @@ func (d *NullDecimal) Scan(src any) error {
 	var err error
 	switch v := src.(type) {
 	case []byte:
-		d.Decimal, err = Parse(string(v))
+		d.Decimal, err = parseBytes(v)
 	case string:
 		d.Decimal, err = Parse(v)
 	case uint64:


### PR DESCRIPTION
## Description
- Use `parseBytes` for NullScan when input is []byte
- Simplified `marshalBinaryU128` implementation