### PR TITLE
fix: deprecated PowInt, replaced by PowInt32

### DIFF
--- a/doc_test.go
+++ b/doc_test.go
@@ -302,6 +302,20 @@ func ExampleDecimal_PowInt() {
 	// 0.6609822195782933439
 }
 
+func ExampleDecimal_PowInt32() {
+	fmt.Println(MustParse("1.23").PowInt32(2))
+	fmt.Println(MustParse("1.23").PowInt32(0))
+	fmt.Println(MustParse("1.23").PowInt32(-2))
+	fmt.Println(MustParse("0").PowInt32(0))
+	fmt.Println(MustParse("0").PowInt32(-2))
+	// Output:
+	// 1.5129 <nil>
+	// 1 <nil>
+	// 0.6609822195782933439 <nil>
+	// 1 <nil>
+	// 0 can't raise zero to a negative power
+}
+
 func ExampleDecimal_Prec() {
 	fmt.Println(MustParse("1.23").Prec())
 	// Output:


### PR DESCRIPTION
## Issue
- #25 
## Description
- Deprecate `PowInt` and replace it by `PowInt32(e int32) (decimal, error)` to handle `0^0` and `0^(negative)` correctly.
- `PowInt`: 0 pow any integer will return 0
- `PowInt32`: 0^0 = 1, 0^(negative integer) will return error