### PR TITLE
feat: add Append interfaces

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ fuzz-all:
 	@sh scripts/fuzz-all.sh $(fuzzTime)
 
 bench:
-	@go test -bench=BenchmarkGVString -benchmem -benchmem -memprofile=mem.out -cpuprofile=cpu.out -run NONE
+	@go test -bench=BenchmarkAppendBinary -benchmem -benchmem -memprofile=mem.out -cpuprofile=cpu.out -run NONE
 
 # https://stackoverflow.com/questions/6273608/how-to-pass-argument-to-makefile-from-command-line
 %:

--- a/README.md
+++ b/README.md
@@ -17,12 +17,13 @@ go get github.com/quagmt/udecimal
 ## Features
 
 - **High Precision**: Supports up to 19 decimal places with no precision loss during arithmetic operations.
-- **Optimized for Speed**: Designed for high performance with zero memory allocation in most cases (see [Benchmarks](benchmarks/README.md) and [How it works](#how-it-works)).
+- **Zero Memory Allocation**: Designed for almost 99% zero memory allocation (see [How it works](#how-it-works)).
+- **Optimized for Speed**: 5x~20x faster than [shopspring/decimal](https://github.com/shopspring/decimal) and [ericlagergren/decimal](https://github.com/ericlagergren/decimal) (see [Benchmark](benchmark/README.md)).
 - **Panic-Free**: All errors are returned as values, ensuring no unexpected panics.
-- **Immutable**: All arithmetic operations return a new `Decimal` value, preserving the original value and safe for concurrent use.
-- **Versatile Rounding Methods**: Includes HALF AWAY FROM ZERO, HALF TOWARD ZERO, and Banker's rounding.
-  <br/>
+- **Concurrent-Safe**: All arithmetic operations return a new `Decimal` value while keeping the original value unchanged, , making it safe to be shared across goroutines.
 - **Correctness**: All arithmetic operations are fuzz tested and cross-checked with `shopspring/decimal` library to ensure correctness.
+- **Versatile Rounding Methods**: Includes HALF AWAY FROM ZERO, HALF TOWARD ZERO, AWAY FROM ZERO, and Banker's rounding.
+  <br/>
 
 **NOTE**: This library does not perform implicit rounding. If the result of an operation exceeds the maximum precision, extra digits are truncated. All rounding methods must be explicitly invoked. (see [Rounding Methods](#rounding-methods) for more details)
 

--- a/benchmarks/benchmarks_test.go
+++ b/benchmarks/benchmarks_test.go
@@ -102,27 +102,27 @@ func BenchmarkString(b *testing.B) {
 
 	for _, tc := range testcases {
 		// shopspring benchmark
-		// b.Run(fmt.Sprintf("ss/%s", tc), func(b *testing.B) {
-		// 	bb := ss.RequireFromString(tc)
+		b.Run(fmt.Sprintf("ss/%s", tc), func(b *testing.B) {
+			bb := ss.RequireFromString(tc)
 
-		// 	b.ResetTimer()
-		// 	for range b.N {
-		// 		_ = bb.String()
-		// 	}
-		// })
+			b.ResetTimer()
+			for range b.N {
+				_ = bb.String()
+			}
+		})
 
-		// // ericlagergren benchmark
-		// b.Run(fmt.Sprintf("eric/%s", tc), func(b *testing.B) {
-		// 	var a ed.Big
-		// 	a.Context.Precision = 19
-		// 	a.Context.RoundingMode = ed.ToNearestEven
-		// 	a.SetString(tc)
+		// ericlagergren benchmark
+		b.Run(fmt.Sprintf("eric/%s", tc), func(b *testing.B) {
+			var a ed.Big
+			a.Context.Precision = 19
+			a.Context.RoundingMode = ed.ToNearestEven
+			a.SetString(tc)
 
-		// 	b.ResetTimer()
-		// 	for range b.N {
-		// 		_ = a.String()
-		// 	}
-		// })
+			b.ResetTimer()
+			for range b.N {
+				_ = a.String()
+			}
+		})
 
 		b.Run(fmt.Sprintf("udec/%s", tc), func(b *testing.B) {
 			bb := udecimal.MustParse(tc)

--- a/benchmarks/benchmarks_test.go
+++ b/benchmarks/benchmarks_test.go
@@ -102,27 +102,27 @@ func BenchmarkString(b *testing.B) {
 
 	for _, tc := range testcases {
 		// shopspring benchmark
-		b.Run(fmt.Sprintf("ss/%s", tc), func(b *testing.B) {
-			bb := ss.RequireFromString(tc)
+		// b.Run(fmt.Sprintf("ss/%s", tc), func(b *testing.B) {
+		// 	bb := ss.RequireFromString(tc)
 
-			b.ResetTimer()
-			for range b.N {
-				_ = bb.String()
-			}
-		})
+		// 	b.ResetTimer()
+		// 	for range b.N {
+		// 		_ = bb.String()
+		// 	}
+		// })
 
-		// ericlagergren benchmark
-		b.Run(fmt.Sprintf("eric/%s", tc), func(b *testing.B) {
-			var a ed.Big
-			a.Context.Precision = 19
-			a.Context.RoundingMode = ed.ToNearestEven
-			a.SetString(tc)
+		// // ericlagergren benchmark
+		// b.Run(fmt.Sprintf("eric/%s", tc), func(b *testing.B) {
+		// 	var a ed.Big
+		// 	a.Context.Precision = 19
+		// 	a.Context.RoundingMode = ed.ToNearestEven
+		// 	a.SetString(tc)
 
-			b.ResetTimer()
-			for range b.N {
-				_ = a.String()
-			}
-		})
+		// 	b.ResetTimer()
+		// 	for range b.N {
+		// 		_ = a.String()
+		// 	}
+		// })
 
 		b.Run(fmt.Sprintf("udec/%s", tc), func(b *testing.B) {
 			bb := udecimal.MustParse(tc)

--- a/bint.go
+++ b/bint.go
@@ -35,12 +35,6 @@ const (
 	ParseModeTrunc
 )
 
-const (
-	// maxDigitU64 is the maximum digits of a number
-	// that can be safely stored in a uint64.
-	maxDigitU64 = 19
-)
-
 var (
 	bigZero = big.NewInt(0)
 	bigOne  = big.NewInt(1)

--- a/codec.go
+++ b/codec.go
@@ -359,6 +359,15 @@ func (d Decimal) MarshalBinary() ([]byte, error) {
 	return d.AppendBinary(nil)
 }
 
+// AppendBinary implements [encoding.BinaryAppender] interface.
+func (d Decimal) AppendBinary(b []byte) ([]byte, error) {
+	if !d.coef.overflow() {
+		return d.appendBinaryU128(b)
+	}
+
+	return d.appendBinaryBigInt(b)
+}
+
 func (d Decimal) appendBinaryU128(input []byte) ([]byte, error) {
 	coef := d.coef.u128
 
@@ -414,15 +423,6 @@ func (d Decimal) appendBinaryBigInt(input []byte) ([]byte, error) {
 func copyUint64ToBytes(b []byte, n uint64) {
 	// use big endian to make it consistent with big.Int.FillBytes, which also uses big endian
 	binary.BigEndian.PutUint64(b, n)
-}
-
-// AppendBinary implements [encoding.BinaryAppender] interface.
-func (d Decimal) AppendBinary(b []byte) ([]byte, error) {
-	if !d.coef.overflow() {
-		return d.appendBinaryU128(b)
-	}
-
-	return d.appendBinaryBigInt(b)
 }
 
 func (d *Decimal) UnmarshalBinary(data []byte) error {

--- a/codec_test.go
+++ b/codec_test.go
@@ -461,6 +461,13 @@ func TestNullScan(t *testing.T) {
 	}
 }
 
+func TestAppendBinaryBigInt(t *testing.T) {
+	d := MustParse("123456.123456")
+
+	_, err := d.appendBinaryBigInt(nil)
+	require.Equal(t, ErrInvalidBinaryData, err)
+}
+
 func BenchmarkAppendText(b *testing.B) {
 	a := make([]byte, 0, 16)
 	d := MustParse("123456.123456")

--- a/doc_test.go
+++ b/doc_test.go
@@ -370,6 +370,19 @@ func ExampleDecimal_MarshalBinary() {
 	// [0 19 19 9 73 176 246 240 2 51 19 211 181 5 249 181 241 129 21] <nil>
 }
 
+func ExampleDecimal_AppendBinary() {
+	a, _ := MustParse("1.23").AppendBinary(nil)
+	b, _ := MustParse("-1.2345").AppendBinary(nil)
+	c, _ := MustParse("1234567890123456789.1234567890123456789").AppendBinary(nil)
+	fmt.Println(a)
+	fmt.Println(b)
+	fmt.Println(c)
+	// Output:
+	// [0 2 11 0 0 0 0 0 0 0 123]
+	// [1 4 11 0 0 0 0 0 0 48 57]
+	// [0 19 19 9 73 176 246 240 2 51 19 211 181 5 249 181 241 129 21]
+}
+
 func ExampleDecimal_MarshalJSON() {
 	a, _ := MustParse("1.23").MarshalJSON()
 	b, _ := MustParse("-1.2345").MarshalJSON()
@@ -387,6 +400,19 @@ func ExampleDecimal_MarshalText() {
 	a, _ := MustParse("1.23").MarshalText()
 	b, _ := MustParse("-1.2345").MarshalText()
 	c, _ := MustParse("1234567890123456789.1234567890123456789").MarshalText()
+	fmt.Println(string(a))
+	fmt.Println(string(b))
+	fmt.Println(string(c))
+	// Output:
+	// 1.23
+	// -1.2345
+	// 1234567890123456789.1234567890123456789
+}
+
+func ExampleDecimal_AppendText() {
+	a, _ := MustParse("1.23").AppendText(nil)
+	b, _ := MustParse("-1.2345").AppendText(nil)
+	c, _ := MustParse("1234567890123456789.1234567890123456789").AppendText(nil)
 	fmt.Println(string(a))
 	fmt.Println(string(b))
 	fmt.Println(string(c))


### PR DESCRIPTION
## Description
- Added [TextAppender](https://pkg.go.dev/encoding#TextAppender) and [BinaryAppender](https://pkg.go.dev/encoding#BinaryAppender) interfaces, which were introduced in go 1.24