### PR TITLE
feat: add support for encoding into URL query parameters

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,37 +1,42 @@
-run:
-  timeout: 5m
-
-linters-settings:
-  nolintlint:
-    # Enable to require an explanation of nonzero length after each nolint directive.
-    # Default: false
-    require-explanation: true
-    # Enable to require nolint directives to mention the specific linter being suppressed.
-    # Default: false
-    require-specific: true
+version: "2"
 
 linters:
   enable:
-    - nolintlint
-    - errcheck
-    - gosimple
-    - goimports
-    - govet
-    - ineffassign
     - gosec
     - misspell
-    - stylecheck
-    - revive
+    - nolintlint
     - predeclared
+    - revive
     - staticcheck
-    - typecheck
-    - unused
+  settings:
+    nolintlint:
+      require-explanation: true
+      require-specific: true
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    rules:
+      - linters:
+          - gosec
+          - govet
+          - staticcheck
+          - unused
+        path: _test.go
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
 
-issues:
-  exclude-rules:
-    - path: "_test.go"
-      linters:
-        - govet
-        - gosec
-        - staticcheck
-        - unused
+formatters:
+  enable:
+    - goimports
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$

--- a/codec.go
+++ b/codec.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"math/big"
 	"math/bits"
+	"net/url"
 	"unsafe"
 )
 
@@ -509,6 +510,14 @@ func (d *Decimal) Scan(src any) error {
 // [driver.Valuer]: https://pkg.go.dev/database/sql/driver#Valuer
 func (d Decimal) Value() (driver.Value, error) {
 	return d.String(), nil
+}
+
+// EncodeValues implements the [query.Encoder] interface by the go-querystring package.
+//
+// [query.Encoder]: https://pkg.go.dev/github.com/google/go-querystring/query#Encoder
+func (d Decimal) EncodeValues(key string, v *url.Values) error {
+	v.Set(key, d.String())
+	return nil
 }
 
 // NullDecimal is a nullable Decimal.

--- a/codec_test.go
+++ b/codec_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/gob"
 	"encoding/json"
 	"fmt"
+	"net/url"
 	"strings"
 	"testing"
 
@@ -408,6 +409,36 @@ func TestScan(t *testing.T) {
 			require.NoError(t, err)
 
 			require.Equal(t, tc.want.String(), val)
+		})
+	}
+}
+
+func TestEncodeValues(t *testing.T) {
+	testcases := []string{
+		"123456789.123456789",
+		"0",
+		"1",
+		"-1",
+		"-123456789.123456789",
+		"0.000000001",
+		"-0.000000001",
+		"123.123",
+		"-123.123",
+		"12345678901234567890123456789.1234567890123456789",
+		"-12345678901234567890123456789.1234567890123456789",
+	}
+
+	for _, in := range testcases {
+		t.Run(in, func(t *testing.T) {
+			d := MustParse(in)
+
+			key := "testKey"
+			want := url.Values{key: []string{d.String()}}
+			got := url.Values{}
+			err := d.EncodeValues(key, &got)
+
+			require.NoError(t, err)
+			require.Equal(t, want, got)
 		})
 	}
 }


### PR DESCRIPTION
This pull request adds support for encoding the `Decimal` type into a URL query parameter using the [`go-querystring`](https://github.com/google/go-querystring) package.

> go-querystring is designed to assist in scenarios where you want to construct a URL using a struct that represents the URL query parameters.

It adds an implementation for the [`Encoder`](https://pkg.go.dev/github.com/google/go-querystring/query#Encoder) interface:
```go
type Encoder interface {
	EncodeValues(key string, v *url.Values) error
}
```

Example usage:
```go
package main

import (
	"fmt"
	"log"

	"github.com/google/go-querystring/query"
	"github.com/quagmt/udecimal"
)

type Params struct {
	Price    udecimal.Decimal `url:"price"`
	Quantity udecimal.Decimal `url:"quantity"`
	Zero     udecimal.Decimal `url:"zero,omitempty"`
}

func main() {
	params := Params{
		Price:    udecimal.MustParse("100"),
		Quantity: udecimal.MustParse("10"),
	}

	v, err := query.Values(params)
	if err != nil {
		log.Fatal(err)
	}

	// Output without this implementation: ""
	// Output after this implementation  : "price=100&quantity=10"
	// Output without omitempty          : "price=100&quantity=10&zero=0"
	fmt.Printf("%q", v.Encode())
}
```

Maybe this is a niche use case, but it doesn't add any overhead to the package.